### PR TITLE
Sample of typed multi()

### DIFF
--- a/lib/TornAPIBase.ts
+++ b/lib/TornAPIBase.ts
@@ -138,7 +138,7 @@ export abstract class TornAPIBase {
         return `https://api.torn.com/${params.route}/${id}?selections=${params.selection}&key=${this.apiKey}${from}${to}${limit}${timestamp}`;
     }
 
-    protected async multiQuery<T>(route: string, endpoints: string[], id?: string): Promise<ITornApiError | Record<string, T>> {
+    async multiQuery<T>(route: string, endpoints: string[], id?: string): Promise<ITornApiError | Record<string, T>> {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const response = await axios.get<any>(this.buildUri({ route: route, selection: endpoints.join(','), id: id }));
         if (response instanceof Error) {

--- a/lib/User.ts
+++ b/lib/User.ts
@@ -11,7 +11,7 @@ export class User extends TornAPIBase {
         return this.multiQuery('user', endpoints, id);
     }
 
-    multi2<T>(id?: string): RequestBuilder<{}> {
+    typedMulti<T>(id?: string): RequestBuilder<{}> {
         return new RequestBuilder<{}>(this, id);
     }
 


### PR DESCRIPTION
Here's an example of how `multi` could be strongly typed.  You'd call it like:

```typescript
TornAPI.User.typedMulti()
      .ammo()
      .bars()
      .fetch()
      .then((result) => {
        if (TornAPI.isError(result)) {
          //
        } else {
          // result has a union of types for ammo and bars
        }
      });
```