### PR TITLE
chore: use URL ctor for api calls

### DIFF
--- a/lib/TornAPIBase.ts
+++ b/lib/TornAPIBase.ts
@@ -115,33 +115,37 @@ export abstract class TornAPIBase {
     }
 
     protected buildUri(params: QueryParams): string {
-        let id = '', from = '', to = '', limit = '', timestamp = '', commentData = '';
+        const url = new URL(`${params.route}/${params.id}`, `https://api.torn.com`);
+        url.searchParams.set('selections', params.selection);
+        url.searchParams.set('key', this.apiKey);
 
-        if (params.id) {
-            id = params.id;
+        if(params.additionalSelections) {
+            for (const key in params.additionalSelections) {
+                url.searchParams.set(key, params.additionalSelections[key]);
+            }
         }
 
         if (params.from) {
-            from = `&from=${params.from}`;
+            url.searchParams.set('from', params.from.toString());
         }
 
         if (params.to) {
-            to = `&to=${params.to}`;
+            url.searchParams.set('to', params.to.toString());
         }
 
         if (params.limit) {
-            limit = `&limit=${params.limit}`;
+            url.searchParams.set('limit', params.limit.toString());
         }
 
         if (params.timestamp) {
-            timestamp = `&timestamp=${params.timestamp}`;
+            url.searchParams.set('timestamp', params.timestamp.toString());
         }
 
         if (this.comment) {
-            commentData = `&comment=${this.comment}`;
+            url.searchParams.set('comment', this.comment);
         }
 
-        return `https://api.torn.com/${params.route}/${id}?selections=${params.selection}&key=${this.apiKey}${from}${to}${limit}${timestamp}${commentData}`;
+        return url.toString();
     }
 
     protected async multiQuery<T>(route: string, endpoints: string[], id?: string): Promise<ITornApiError | Record<string, T>> {
@@ -170,4 +174,5 @@ interface QueryParams {
     to?: number;
     limit?: number;
     timestamp?: number;
+    additionalSelections?: Record<string, string>;
 }

--- a/lib/User.ts
+++ b/lib/User.ts
@@ -200,11 +200,10 @@ export class User extends TornAPIBase {
     }
 
     async personalstats(id?: string, timestamp?: number, stat?: IUserStats[]): Promise<Errorable<IPersonalStats | Partial<IPersonalStats>>> {
-        let selection = 'personalstats';
         if (stat) {
-          selection += `&stat=${stat.join(',')}`;
+            return this.apiQuery({ route: 'user', selection: 'personalstats', timestamp: timestamp, id: id, jsonOverride: 'personalstats', additionalSelections: { 'stat': `${stat.join(',')}` } });
         }
-        return this.apiQuery({ route: 'user', selection: selection, timestamp: timestamp, id: id, jsonOverride: 'personalstats' });
+        return this.apiQuery({ route: 'user', selection: 'personalstats', timestamp: timestamp, id: id, jsonOverride: 'personalstats' });
     }
 
     async profile(id?: string): Promise<Errorable<IUser>> {

--- a/test/User.test.ts
+++ b/test/User.test.ts
@@ -63,7 +63,10 @@ describe('User API', () => {
 
         const initialReturn = await torn.user.personalstats('123', 123456, ['bazaarsales', 'mailssent', 'rifhits']);
         expect(TornAPI.isError(initialReturn)).to.be.false;
-        expect(stub.args[0][0]).to.equal('https://api.torn.com/user/123?selections=personalstats&stat=bazaarsales,mailssent,rifhits&key=key&timestamp=123456');
+        expect(stub.args[0][0]).to.contain('https://api.torn.com/user/123');
+        expect(stub.args[0][0]).to.contain('selections=personalstats');
+        expect(stub.args[0][0]).to.contain('stat=bazaarsales%2Cmailssent%2Crifhits');
+        expect(stub.args[0][0]).to.contain('timestamp=123456');
 
         const castedReturn = initialReturn as Partial<IPersonalStats>;
 


### PR DESCRIPTION
This started out as a way to remove string concats for building the URL for the API (https://twitter.com/Steve8708/status/1612907638957932544). As part of that, refactored the creation of the individual stats for personal stats to be more generic. 