### PR TITLE
feat: add torn dirtybombs call

### DIFF
--- a/lib/Interfaces.ts
+++ b/lib/Interfaces.ts
@@ -1157,6 +1157,15 @@ export interface ITornCompany {
     specials: ICompanySpecial[];
 }
 
+export interface ITornDirtyBomb {
+    planted: number;
+    detonated: number;
+    injured: number;
+    respect: number;
+    faction: number;
+    user: number;
+}
+
 export interface IEducationResults {
     perk?: string[];
     manual_labor?: string[];

--- a/lib/Torn.ts
+++ b/lib/Torn.ts
@@ -30,7 +30,8 @@ import {
     ICityShop,
     IItemDetails,
     ISearchForCashCrimeStatus,
-    IShopliftingCrimeStatus
+    IShopliftingCrimeStatus,
+    ITornDirtyBomb
 } from './Interfaces';
 import { TornAPIBase } from './TornAPIBase';
 
@@ -111,6 +112,10 @@ export class Torn extends TornAPIBase {
 
             return TornAPIBase.GenericAPIError;
         }
+    }
+
+    async dirtybombs(): Promise<Errorable<ITornDirtyBomb[]>> {
+        return this.apiQueryToArray({ route: 'torn', selection: 'dirtybombs' });
     }
 
     async education(): Promise<Errorable<ITornEducation[]>> {

--- a/test/Torn.test.ts
+++ b/test/Torn.test.ts
@@ -28,6 +28,7 @@ import {
     ITerritoryDetail,
     ITerritoryWar,
     ITornCompany,
+    ITornDirtyBomb,
     ITornEducation,
     ITornGym,
     ITornProperty,
@@ -142,6 +143,20 @@ describe('Torn API', () => {
         //spot check one
         const special = company?.specials.find((x) => x.name === 'High-fidelity');
         expect(special?.effect).to.equal('Reduced enemy stealth');
+    });
+
+    it('dirtybombs', async () => {
+        sinon.stub(axios, 'get').resolves(TestHelper.getJSON('torn_dirtybombs'));
+
+        const initialReturn = await torn.torn.dirtybombs();
+        expect(TornAPI.isError(initialReturn)).to.be.false;
+
+        const castedReturn = initialReturn as ITornDirtyBomb[];
+
+        // spot check one
+        const dirtybomb = castedReturn.find((x) => x.planted === 1693407593);
+        expect(dirtybomb?.injured).to.equal(613);
+        expect(dirtybomb?.user).to.be.null;
     });
 
     it('education', async () => {

--- a/test/utils/tests.json
+++ b/test/utils/tests.json
@@ -6111,6 +6111,26 @@
             }
         }
     },
+    "torn_dirtybombs": {
+        "dirtybombs": [
+                {
+                        "planted": 1714309601,
+                        "detonated": 1714316465,
+                        "injured": 721,
+                        "respect": 411674,
+                        "faction": 8836,
+                        "user": 459981
+                },
+                {
+                        "planted": 1693407593,
+                        "detonated": 1693411273,
+                        "injured": 613,
+                        "respect": 616637,
+                        "faction": 8706,
+                        "user": null
+                }
+        ]
+    },
     "torn_education": {
         "education": {
             "1": {


### PR DESCRIPTION
Updates for patch 337.

- [API] Added 'torn' -> 'dirtybombs' selection for a list of dirty bombs that have been planted or detonated

https://www.torn.com/forums.php#/p=threads&f=1&t=16397714&b=0&a=0