### PR TITLE
fix: support IDs in faction/chain and faction/territory

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -6,6 +6,7 @@
     "htmlWhitespaceSensitivity": "css",
     "insertPragma": false,
     "jsxSingleQuote": false,
+    "endOfLine": "crlf",
     "printWidth": 160,
     "proseWrap": "preserve",
     "quoteProps": "as-needed",

--- a/lib/Faction.ts
+++ b/lib/Faction.ts
@@ -118,8 +118,8 @@ export class Faction extends TornAPIBase {
         throw new Error('Method not implemented.');
     }
 
-    async chain(): Promise<Errorable<IChain>> {
-        return this.apiQuery({ route: 'faction', selection: 'chain' });
+    async chain(id?: string): Promise<Errorable<IChain>> {
+        return this.apiQuery({ route: 'faction', selection: 'chain', id });
     }
 
     async chainreport(): Promise<Errorable<IChainReport>> {
@@ -279,8 +279,8 @@ export class Faction extends TornAPIBase {
         return this.apiQuery({ route: 'faction', selection: 'temporary' });
     }
 
-    async territory(): Promise<Errorable<ITerritory[]>> {
-        return this.apiQueryToArray({ route: 'faction', selection: 'territory' }, 'id');
+    async territory(id?: string): Promise<Errorable<ITerritory[]>> {
+        return this.apiQueryToArray({ route: 'faction', selection: 'territory', id }, 'id');
     }
 
     async territorynews(from?: number, to?: number): Promise<Errorable<INews[]>> {

--- a/lib/TornAPIBase.ts
+++ b/lib/TornAPIBase.ts
@@ -115,7 +115,7 @@ export abstract class TornAPIBase {
     }
 
     protected buildUri(params: QueryParams): string {
-        const url = new URL(`${params.route}/${params.id}`, `https://api.torn.com`);
+        const url = new URL(`${params.route}/${params.id ?? ''}`, `https://api.torn.com`);
         url.searchParams.set('selections', params.selection);
         url.searchParams.set('key', this.apiKey);
 


### PR DESCRIPTION
- 4065e66587ad30fbf9ffdc6bcfbcdb061d33162b:  running `npm run format` would change all line endings (on my machine) to LF, now it will force prettier to use CLRF (else the diff ends up being every single file)
- 7e227e773b0589832ea1a810d75ac06f63411373: This presumably wasn't noticed as for some sections no error will be thrown (`https://api.torn.com/user/undefined?key=xxx&selections=basic` will default to the current user's id, `https://api.torn.com/faction/undefined?key=xxx&selections=territory` will not).
- c42278f6d8f247fdfe4483cd31518ff9892a46a7: self explanatory